### PR TITLE
Use boost imported target whenever possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,19 @@ add_library(${PROJECT_NAME}
 )
 
 find_package(Boost REQUIRED)
+if(CMAKE_VERSION VERSION_LESS 3.5)
+    # Boost imported targets were introduced in CMake 3.5
+    # Fallback to a traditional but less generic approach
+    target_include_directories(${PROJECT_NAME}
+        PUBLIC
+            ${Boost_INCLUDE_DIR}
+    )
+else()
+    target_link_libraries(${PROJECT_NAME}
+        PUBLIC
+            Boost::boost
+    )
+endif()
 
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
@@ -29,7 +42,6 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-        ${Boost_INCLUDE_DIR}
 )
 
 # If we have compiler requirements for this library, list them here


### PR DESCRIPTION
Using the imported target rather than the installed boost path makes the
installation of bustache relocatable by not relying on the build machine
setup for the Boost include path.

I have kept compatibility for CMake version less than 3.5, if you don't mind bumping the minimun_required_version I can also clean up the patch. Your call.