### PR TITLE
Resolve #11: qualify calls to bustache::visit to avoid wrong overload

### DIFF
--- a/include/bustache/detail/variant.hpp
+++ b/include/bustache/detail/variant.hpp
@@ -156,14 +156,14 @@ namespace bustache
     inline auto apply_visitor(Visitor&& visitor, variant_base<Var>& v) ->
         decltype(Var::switcher::common_ret((void*)nullptr, visitor))
     {
-        return visit(std::forward<Visitor>(visitor), v);
+        return bustache::visit(std::forward<Visitor>(visitor), v);
     }
 
     template<class Visitor, class Var>
     inline auto apply_visitor(Visitor&& visitor, variant_base<Var> const& v) ->
         decltype(Var::switcher::common_ret((void const*)nullptr, visitor))
     {
-        return visit(std::forward<Visitor>(visitor), v);
+        return bustache::visit(std::forward<Visitor>(visitor), v);
     }
 
     template<class T, class Var>

--- a/include/bustache/generate.hpp
+++ b/include/bustache/generate.hpp
@@ -89,11 +89,11 @@ namespace bustache { namespace detail
             auto it = data.begin(), end = data.end();
             if (it != end)
             {
-                visit(*this, *it);
+                bustache::visit(*this, *it);
                 while (++it != end)
                 {
                     literal(",");
-                    visit(*this, *it);
+                    bustache::visit(*this, *it);
                 }
             }
         }
@@ -103,7 +103,7 @@ namespace bustache { namespace detail
             {
                 value_holder hold;
                 if (auto pv = cursor.next(hold))
-                    visit(*this, *pv);
+                    bustache::visit(*this, *pv);
                 else
                     return;
             }
@@ -113,7 +113,7 @@ namespace bustache { namespace detail
                 if (auto pv = cursor.next(hold))
                 {
                     literal(",");
-                    visit(*this, *pv);
+                    bustache::visit(*this, *pv);
                 }
                 else
                     break;
@@ -127,12 +127,12 @@ namespace bustache { namespace detail
 
         void operator()(lambda0v const& data) const
         {
-            visit(*this, data());
+            bustache::visit(*this, data());
         }
 
         void operator()(lambda1v const& data) const
         {
-            visit(*this, data({}));
+            bustache::visit(*this, data({}));
         }
 
         template<class Sig>
@@ -254,7 +254,7 @@ namespace bustache { namespace detail
         {
             auto fmt(data());
             for (auto const& content : fmt.contents())
-                visit(parent, content);
+                bustache::visit(parent, content);
         }
     };
 
@@ -270,7 +270,7 @@ namespace bustache { namespace detail
         void expand() const
         {
             for (auto const& content : contents)
-                visit(parent, content);
+                bustache::visit(parent, content);
         }
 
         void expand_with_scope(object_view data) const
@@ -355,7 +355,7 @@ namespace bustache { namespace detail
 
         bool operator()(lambda0v const& data) const
         {
-            return inverted ? false : visit(*this, data());
+            return inverted ? false : bustache::visit(*this, data());
         }
 
         bool operator()(lambda0f const& data) const
@@ -364,14 +364,14 @@ namespace bustache { namespace detail
             {
                 auto fmt(data());
                 for (auto const& content : fmt.contents())
-                    visit(parent, content);
+                    bustache::visit(parent, content);
             }
             return false;
         }
 
         bool operator()(lambda1v const& data) const
         {
-            return inverted ? false : visit(*this, data(contents));
+            return inverted ? false : bustache::visit(*this, data(contents));
         }
 
         bool operator()(lambda1f const& data) const
@@ -380,7 +380,7 @@ namespace bustache { namespace detail
             {
                 auto fmt(data(contents));
                 for (auto const& content : fmt.contents())
-                    visit(parent, content);
+                    bustache::visit(parent, content);
             }
             return false;
         }
@@ -421,7 +421,7 @@ namespace bustache { namespace detail
             {
                 *this, escaping && !variable.tag
             };
-            visit(visitor, val);
+            bustache::visit(visitor, val);
         }
 
         void handle_section(ast::section const& section, value_view val)
@@ -433,10 +433,10 @@ namespace bustache { namespace detail
                 *this, section.contents, inverted
             };
             cursor = val.get_pointer();
-            if (visit(visitor, val))
+            if (bustache::visit(visitor, val))
             {
                 for (auto const& content : section.contents)
-                    visit(*this, content);
+                    bustache::visit(*this, content);
             }
             cursor = old_cursor;
         }
@@ -519,7 +519,7 @@ namespace bustache { namespace detail
                 if (!partial.overriders.empty())
                     chain.push_back(&partial.overriders);
                 for (auto const& content : p->contents())
-                    visit(*this, content);
+                    bustache::visit(*this, content);
                 chain.resize(old_chain);
                 indent.resize(old_size);
             }
@@ -531,7 +531,7 @@ namespace bustache { namespace detail
             if (!pc)
                 pc = &block.contents;
             for (auto const& content : *pc)
-                visit(*this, content);
+                bustache::visit(*this, content);
         }
 
         void operator()(ast::null) const {} // never called
@@ -564,7 +564,7 @@ namespace bustache
             std::forward<UnresolvedHandler>(f), bool(flag)
         };
         for (auto const& content : fmt.contents())
-            visit(visitor, content);
+            bustache::visit(visitor, content);
     }
 }
 

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -432,7 +432,7 @@ namespace bustache
         {
             std::size_t n = 0;
             for (auto const& content : section.contents)
-                n += visit(*this, content);
+                n += bustache::visit(*this, content);
             return n;
         }
 
@@ -448,7 +448,7 @@ namespace bustache
         accum_size accum;
         std::size_t n = 0;
         for (auto const& content : _contents)
-            n += visit(accum, content);
+            n += bustache::visit(accum, content);
         return n;
     }
 
@@ -467,7 +467,7 @@ namespace bustache
         void operator()(ast::section& section) noexcept
         {
             for (auto& content : section.contents)
-                visit(*this, content);
+                bustache::visit(*this, content);
         }
 
         template <typename T>
@@ -479,6 +479,6 @@ namespace bustache
         _text.reset(new char[n]);
         copy_text_visitor visitor{_text.get()};
         for (auto& content : _contents)
-            visit(visitor, content);
+            bustache::visit(visitor, content);
     }
 }

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -234,9 +234,9 @@ TEST_CASE("variant-valuess-by-exception")
 TEST_CASE("variant-visit")
 {
     Visitor v;
-    CHECK(visit(v, Var{}) == 0);
-    CHECK(visit(v, Var{true}) == 0);
-    CHECK(visit(v, Var{0}) == 1);
-    CHECK(visit(v, Var{A{}}) == 2);
-    CHECK(visit(v, Var{BadCopy{}}) == 3);
+    CHECK(bustache::visit(v, Var{}) == 0);
+    CHECK(bustache::visit(v, Var{true}) == 0);
+    CHECK(bustache::visit(v, Var{0}) == 1);
+    CHECK(bustache::visit(v, Var{A{}}) == 2);
+    CHECK(bustache::visit(v, Var{BadCopy{}}) == 3);
 }


### PR DESCRIPTION
The visit implementation provided by bustache are not in the exact
namespace as the parameters preventing ADL to correctly choose the
bustache implementation in some cases.
When std::visit from C++17 is also in scope it is preferred.
Qualifying the visit calls to force the bustache implementation.