### PR TITLE
Closes #15: Improve CMake package integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,10 @@ export(EXPORT bustache-targets NAMESPACE bustache::)
 configure_file(cmake/bustache-config.cmake.in bustache-config.cmake @ONLY)
 install(FILES "${PROJECT_BINARY_DIR}/bustache-config.cmake" DESTINATION share/bustache/cmake)
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(bustache-config-version.cmake VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+install(FILES "${PROJECT_BINARY_DIR}/bustache-config-version.cmake" DESTINATION share/bustache/cmake)
+
 if (BUSTACHE_ENABLE_TESTING)
     enable_testing()
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT CMAKE_BUILD_TYPE)
     "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel.")
 endif()
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} STATIC
     src/format.cpp
     src/generate.cpp
 )
@@ -87,4 +87,3 @@ endif()
 if (EXPORT_BUILD_DIR)
     export(PACKAGE ${PROJECT_NAME})
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 project(bustache VERSION 1.0.0 LANGUAGES CXX)
 
 option(BUSTACHE_ENABLE_TESTING "Enable testing of the bustache library." OFF)
+option(EXPORT_BUILD_DIR "Export build directory using CMake (enables external use without install)" OFF)
 
 # Set the default CMAKE_BUILD_TYPE to Release.
 # This should be done before the project command since the latter can set
@@ -70,10 +71,14 @@ install(TARGETS ${PROJECT_NAME} EXPORT bustache-config
 )
 install(DIRECTORY include/ DESTINATION include)
 install(EXPORT bustache-config NAMESPACE bustache:: DESTINATION share/bustache/cmake)
-
-export(TARGETS ${PROJECT_NAME} FILE bustache-config.cmake)
+export(EXPORT bustache-config NAMESPACE bustache::)
 
 if (BUSTACHE_ENABLE_TESTING)
     enable_testing()
     add_subdirectory(test)
 endif()
+
+if (EXPORT_BUILD_DIR)
+    export(PACKAGE ${PROJECT_NAME})
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,14 +64,16 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # 'make install' to the correct location
-install(TARGETS ${PROJECT_NAME} EXPORT bustache-config
+install(TARGETS ${PROJECT_NAME} EXPORT bustache-targets
     ARCHIVE  DESTINATION lib
     LIBRARY  DESTINATION lib
     RUNTIME  DESTINATION bin  # This is for Windows
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT bustache-config NAMESPACE bustache:: DESTINATION share/bustache/cmake)
-export(EXPORT bustache-config NAMESPACE bustache::)
+install(EXPORT bustache-targets NAMESPACE bustache:: DESTINATION share/bustache/cmake)
+export(EXPORT bustache-targets NAMESPACE bustache::)
+configure_file(cmake/bustache-config.cmake.in bustache-config.cmake @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/bustache-config.cmake" DESTINATION share/bustache/cmake)
 
 if (BUSTACHE_ENABLE_TESTING)
     enable_testing()

--- a/cmake/bustache-config.cmake.in
+++ b/cmake/bustache-config.cmake.in
@@ -1,0 +1,7 @@
+
+# Find all dependencies.
+include(CMakeFindDependencyMacro)
+find_dependency(Boost QUIET REQUIRED)
+
+# Import targets.
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")


### PR DESCRIPTION
Closes #15. See issue description for motivation of changes.

Note that I also snuck in an additional change which declares bustache a static library. That means it will be built as a static library even if the global flag [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) is enabled.

Reason: To support compiling bustache as a shared library, it would require either a DEF file or `__declspec(dllexport)` annotations for all exported functions. This is necessary on Windows but also desirable on Unix-like platforms which unfortunately default to exporting *all* symbols. I think bustache isn't a good candidate for a shared library, so instead of going through all the hassle, we can just say it will always be a static library.