### PR TITLE
Fix fmt dependency in exported cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ if(BUSTACHE_USE_FMT)
     PUBLIC
         fmt::fmt
   )
-  add_compile_definitions(BUSTACHE_USE_FMT)
+  target_compile_definitions(
+    ${PROJECT_NAME}
+    PUBLIC
+      BUSTACHE_USE_FMT
+  )
 endif()
 
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/cmake/bustache-config.cmake.in
+++ b/cmake/bustache-config.cmake.in
@@ -1,4 +1,9 @@
 @PACKAGE_INIT@
 
+set(BUSTACHE_USE_FMT @BUSTACHE_USE_FMT@)
+if(BUSTACHE_USE_FMT)
+  include(CMakeFindDependencyMacro)
+  find_dependency(fmt QUIET REQUIRED)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
-check_required_components(fmt)


### PR DESCRIPTION
Use `find_dependency` to find fmt if required. I don't think `check_required_components` was meant to do that, but rather to validate components (as in `find_package(COMPONENTS)` keyword), which bustache does not use/have.

The `BUSTACHE_USE_FMT` must also be exposed to the client users when required, otherwise it will fall back to the standard `<format>` version.