### PR TITLE
fix bustache::literals::operator""_fmt calls incorrect format ctor

### DIFF
--- a/include/bustache/format.hpp
+++ b/include/bustache/format.hpp
@@ -149,7 +149,7 @@ namespace bustache
     {
         inline format operator"" _fmt(char const* str, std::size_t n)
         {
-            return format(str, str + n);
+            return format(std::string_view(str, n));
         }
     }
 }


### PR DESCRIPTION
The operator"" _fmt originally called format(char const* begin, char const* end), but after a rewrite this function was deleted, in favour of std::string_view, but this operator was left with the char const* begin, char const* end arguments,

It currently calls the 
`format(std::string_view source, bool copytext)` due to implicit conversions (char const* -> std::string_view, and char const* -> bool) which is probably not what we want.